### PR TITLE
chore(DEV-1039): revert changes as public repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
     name: Java ${{ matrix.java }}
     steps:
       - name: Checkout
-        uses: zuvaai/github-actions/checkout@main
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Java
-        uses: zuvaai/github-actions/setup-java@main
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
- reverting changes as this is a public repo it can't consume private repo composite action
- We can look at management in a separate ticket